### PR TITLE
Update magento/module-sales dependency for Magento version 2.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.6",
-        "magento/module-sales": "^101.0.2",
-        "magento/framework": "^100.1.2"
+        "magento/module-sales": "^100.1.2|^101.0.2",
+        "magento/framework": "^100.1.2|^101.0.2"
     },
     "autoload": {
         "files": [ "registration.php" ],

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "magento/module-sales": "^100.1.2",
+        "magento/module-sales": "^101.0.2",
         "magento/framework": "^100.1.2"
     },
     "autoload": {


### PR DESCRIPTION
Summary
------------

Update magento/module-sales dependency for Magento version 2.2.2. This is to fix the following error when updating Magento to version `2.2.*`:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - snowio/magento2-extended-sales-repositories v2.0.0 requires magento/module-sales ^100.1.2 -> satisfiable by magento/module-sales[100.1.3, 100.1.5, 100.1.2, 100.1.4, 100.1.6, 100.2.0-rc20, 100.1.10, 100.1.9, 100.1.7, 100.1.8].
```