### PR TITLE
Add Magento 2.3.1 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.6",
-        "magento/module-sales": "^100.1.2|^101.0.2",
-        "magento/framework": "^100.1.2|^101.0.2"
+        "magento/module-sales": "^100.1.2|^101.0.2|^102.0.1",
+        "magento/framework": "^100.1.2|^101.0.2|^102.0.1"
     },
     "autoload": {
         "files": [ "registration.php" ],


### PR DESCRIPTION
### Description
This PR updates the composer version constraints to support Magento 2.3.1. No additional modifications were needed