### PR TITLE
Implement model OrderRelatedData in order to persist some key/values info

### DIFF
--- a/Api/Data/OrderRelatedDataInterface.php
+++ b/Api/Data/OrderRelatedDataInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace SnowIO\ExtendedSalesRepositories\Api\Data;
+
+/**
+ * Interface OrderRelatedDataInterface
+ * @package SnowIO\ExtendedSalesRepositories\Api\Data
+ */
+
+interface OrderRelatedDataInterface
+{
+    const ID = 'id';
+    const ORDER_INCREMENT_ID = 'order_increment_id';
+    const CODE = 'code';
+    const VALUE = 'value';
+
+    /**
+     * @return string
+     */
+    public function getOrderIncrementId();
+
+    /**
+     * @param string $orderIncrementId
+     *
+     * @return mixed
+     */
+    public function setOrderIncrementId($orderIncrementId);
+
+    /**
+     * @return string
+     */
+    public function getCode();
+
+    /**
+     * @param string $code
+     *
+     * @return mixed
+     */
+    public function setCode($code);
+
+    /**
+     * @return string
+     */
+    public function getValue();
+
+    /**
+     * @param string $value
+     *
+     * @return mixed
+     */
+    public function setValue($value);
+
+}

--- a/Api/Data/OrderRelatedDataSearchResultsInterface.php
+++ b/Api/Data/OrderRelatedDataSearchResultsInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace SnowIO\ExtendedSalesRepositories\Api\Data;
+
+use Magento\Framework;
+
+interface OrderRelatedDataSearchResultsInterface extends Framework\Api\SearchResultsInterface
+{
+    /**
+     * @return OrderRelatedDataInterface[]
+     * @api
+     */
+    public function getItems();
+
+    /**
+     * @param OrderRelatedDataInterface[] $items
+     *
+     * @return $this
+     * @api
+     */
+    public function setItems(array $items);
+}

--- a/Api/OrderRelatedDataRepositoryInterface.php
+++ b/Api/OrderRelatedDataRepositoryInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace SnowIO\ExtendedSalesRepositories\Api;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+use SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface;
+
+/**
+ * Class OrderRelatedDataRepositoryInterface
+ *
+ * @api
+ */
+interface OrderRelatedDataRepositoryInterface
+{
+    /**
+     * Save Order Related Data
+     *
+     * @param OrderRelatedDataInterface $orderRelatedData
+     * @return OrderRelatedDataInterface
+     */
+    public function save(OrderRelatedDataInterface $orderRelatedData);
+
+    /**
+     * Retrieve list of order related data matching given criteria
+     * @param SearchCriteriaInterface $searchCriteria
+     * @return mixed
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria);
+
+    /**
+     * Retrieve Order Related Data by Order Increment ID and Code
+     *
+     * @param string $orderIncrementId
+     * @param string $code
+     * @return \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getByOrderIncrementIdAndCode($orderIncrementId, $code);
+
+    /**
+     * Delete Order Related Data
+     *
+     * @param OrderRelatedDataInterface $orderRelatedData
+     * @return bool true on success
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function delete(OrderRelatedDataInterface $orderRelatedData);
+}

--- a/Api/OrderRelatedDataRepositoryInterface.php
+++ b/Api/OrderRelatedDataRepositoryInterface.php
@@ -15,14 +15,14 @@ interface OrderRelatedDataRepositoryInterface
     /**
      * Save Order Related Data
      *
-     * @param OrderRelatedDataInterface $orderRelatedData
-     * @return OrderRelatedDataInterface
+     * @param \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface $orderRelatedData
+     * @return \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface
      */
     public function save(OrderRelatedDataInterface $orderRelatedData);
 
     /**
      * Retrieve list of order related data matching given criteria
-     * @param SearchCriteriaInterface $searchCriteria
+     * @param \Magento\Framework\Api\SearchCriteriaInterface $searchCriteria
      * @return mixed
      */
     public function getList(SearchCriteriaInterface $searchCriteria);
@@ -39,9 +39,15 @@ interface OrderRelatedDataRepositoryInterface
     public function getByOrderIncrementIdAndCode($orderIncrementId, $code);
 
     /**
+     * @param $orderIncrementId
+     * @return \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface
+     */
+    public function getAllByIncrementId($orderIncrementId);
+
+    /**
      * Delete Order Related Data
      *
-     * @param OrderRelatedDataInterface $orderRelatedData
+     * @param \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface $orderRelatedData
      * @return bool true on success
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @throws \Magento\Framework\Exception\LocalizedException

--- a/Model/OrderRelatedData.php
+++ b/Model/OrderRelatedData.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace SnowIO\ExtendedSalesRepositories\Model;
+
+use Magento\Framework\Model\AbstractModel;
+use SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface;
+use Magento\Framework\DataObject\IdentityInterface;
+use Magento\Framework\Exception\LocalizedException;
+
+class OrderRelatedData extends AbstractModel implements IdentityInterface, OrderRelatedDataInterface
+{
+    const CACHE_TAG = 'snowio_order_relateddata';
+
+    /**
+     * @inheritdoc
+     */
+    protected function _construct()
+    {
+        $this->_cacheTag = self::CACHE_TAG;
+        $this->_eventPrefix = ResourceModel\OrderRelatedData::TABLE;
+        $this->_init(ResourceModel\OrderRelatedData::class);
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getIdentities()
+    {
+        return [self::CACHE_TAG . '_' . $this->getId()];
+    }
+
+    /**
+     * @return string
+     * @throws LocalizedException
+     */
+    public function getCode()
+    {
+        return trim($this->getData(self::CODE));
+    }
+
+    /**
+     * @param string $code
+     *
+     * @return mixed
+     * @throws LocalizedException
+     */
+    public function setCode($code)
+    {
+        $this->setData(self::CODE, trim($code));
+    }
+
+    /**
+     * @return string
+     */
+    public function getValue()
+    {
+        return $this->getData(self::VALUE);
+    }
+
+    /**
+     * @param string $value
+     *
+     * @return mixed
+     * @throws LocalizedException
+     */
+    public function setValue($value)
+    {
+        $this->setData(self::VALUE, $value);
+    }
+
+    /**
+     * @return string
+     */
+    public function getOrderIncrementId()
+    {
+        return $this->getData(self::ORDER_INCREMENT_ID);
+    }
+
+    /**
+     * @param string $incrementId
+     *
+     * @return mixed
+     * @throws LocalizedException
+     */
+    public function setOrderIncrementId($incrementId)
+    {
+        $this->setData(self::ORDER_INCREMENT_ID, $incrementId);
+    }
+
+}

--- a/Model/OrderRelatedDataRepository.php
+++ b/Model/OrderRelatedDataRepository.php
@@ -43,8 +43,8 @@ class OrderRelatedDataRepository implements OrderRelatedDataRepositoryInterface
     }
 
     /**
-     * @param OrderRelatedDataInterface $orderRelatedData
-     * @return OrderRelatedDataInterface
+     * @param \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface $orderRelatedData
+     * @return \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface
      * @throws CouldNotSaveException
      */
     public function save(OrderRelatedDataInterface $orderRelatedData)
@@ -109,7 +109,7 @@ class OrderRelatedDataRepository implements OrderRelatedDataRepositoryInterface
      *
      * @param string $orderIncrementId
      * @param string $code
-     * @return OrderRelatedDataInterface
+     * @return \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface
      * @throws \Magento\Framework\Exception\LocalizedException
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      */
@@ -126,9 +126,26 @@ class OrderRelatedDataRepository implements OrderRelatedDataRepositoryInterface
     }
 
     /**
+     * Retrieve All Order Related Data by Order Increment ID
+     *
+     * @param string $orderIncrementId
+     * @return \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getAllByIncrementId($orderIncrementId)
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter(OrderRelatedDataInterface::ORDER_INCREMENT_ID, $orderIncrementId, 'eq')
+            ->create();
+
+        return $this->getList($searchCriteria)->getItems();
+    }
+
+    /**
      * Delete by Order Related Data
      *
-     * @param OrderRelatedDataInterface $orderRelatedData
+     * @param \SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface $orderRelatedData
      * @return bool
      * @throws \Magento\Framework\Exception\NoSuchEntityException
      * @throws \Magento\Framework\Exception\LocalizedException

--- a/Model/OrderRelatedDataRepository.php
+++ b/Model/OrderRelatedDataRepository.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace SnowIO\ExtendedSalesRepositories\Model;
+
+use Magento\Framework\Api\SearchCriteriaInterface;
+use Magento\Framework\Api\Search;
+use Magento\Framework\Api\SortOrder;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\Exception\CouldNotDeleteException;
+use Magento\Framework\Exception\CouldNotSaveException;
+use Magento\Framework\Exception\NoSuchEntityException;
+use SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface;
+use SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataSearchResultsInterface;
+use SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataSearchResultsInterfaceFactory;
+use SnowIO\ExtendedSalesRepositories\Api\OrderRelatedDataRepositoryInterface;
+use SnowIO\ExtendedSalesRepositories\Model\ResourceModel\OrderRelatedData\Collection;
+
+class OrderRelatedDataRepository implements OrderRelatedDataRepositoryInterface
+{
+    /** @var ResourceModel\OrderRelatedData */
+    protected $resource;
+
+    /** @var OrderRelatedDataFactory */
+    protected $factory;
+
+    /** @var SearchCriteriaBuilder */
+    private $searchCriteriaBuilder;
+
+    /** @var OrderRelatedDataSearchResultsInterfaceFactory */
+    private $searchResultsFactory;
+
+    public function __construct(
+        OrderRelatedDataFactory $factory,
+        ResourceModel\OrderRelatedData $resource,
+        SearchCriteriaBuilder $searchCriteriaBuilder,
+        OrderRelatedDataSearchResultsInterfaceFactory $searchResultsFactory
+    )
+    {
+        $this->factory = $factory;
+        $this->resource = $resource;
+        $this->searchCriteriaBuilder = $searchCriteriaBuilder;
+        $this->searchResultsFactory = $searchResultsFactory;
+    }
+
+    /**
+     * @param OrderRelatedDataInterface $orderRelatedData
+     * @return OrderRelatedDataInterface
+     * @throws CouldNotSaveException
+     */
+    public function save(OrderRelatedDataInterface $orderRelatedData)
+    {
+        try {
+            $savedRelatedData = $this->getByOrderIncrementIdAndCode(
+                $orderRelatedData->getOrderIncrementId(),
+                $orderRelatedData->getCode()
+            );
+
+            if($savedRelatedData instanceof OrderRelatedDataInterface){
+                $savedRelatedData->setValue($orderRelatedData->getValue());
+                $this->resource->save($savedRelatedData);
+                return $savedRelatedData;
+            }
+
+            $this->resource->save($orderRelatedData);
+
+            return $orderRelatedData;
+
+        } catch (\Exception $exception) {
+            throw new CouldNotSaveException(__($exception->getMessage()));
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getList(SearchCriteriaInterface $searchCriteria)
+    {
+        /** @var OrderRelatedDataSearchResultsInterface $searchResults */
+        $searchResults = $this->searchResultsFactory->create();
+
+        $searchResults->setSearchCriteria($searchCriteria);
+        /** @var ResourceModel\OrderRelatedData\Collection $collection */
+        $collection = $this->factory->create()->getCollection();
+
+        // Add filters from root filter group to the collection
+        foreach ($searchCriteria->getFilterGroups() as $group) {
+            $this->addFilterGroupToCollection($group, $collection);
+        }
+        $searchResults->setTotalCount($collection->getSize());
+        $sortOrders = $searchCriteria->getSortOrders();
+        if ($sortOrders) {
+            /** @var SortOrder $sortOrder */
+            foreach ($sortOrders as $sortOrder) {
+                $field = $sortOrder->getField();
+                $collection->addOrder(
+                    $field,
+                    ($sortOrder->getDirection() == SortOrder::SORT_ASC) ? 'ASC' : 'DESC'
+                );
+            }
+        }
+        $collection->setCurPage($searchCriteria->getCurrentPage());
+        $collection->setPageSize($searchCriteria->getPageSize());
+        $searchResults->setItems($collection->getItems());
+        return $searchResults;
+    }
+
+    /**
+     * Retrieve Order Related Data by Order Increment ID and Code
+     *
+     * @param string $orderIncrementId
+     * @param string $code
+     * @return OrderRelatedDataInterface
+     * @throws \Magento\Framework\Exception\LocalizedException
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     */
+    public function getByOrderIncrementIdAndCode($orderIncrementId, $code)
+    {
+        $searchCriteria = $this->searchCriteriaBuilder
+            ->addFilter(OrderRelatedDataInterface::ORDER_INCREMENT_ID, $orderIncrementId, 'eq')
+            ->addFilter(OrderRelatedDataInterface::CODE, trim($code), 'eq')
+            ->create();
+
+        $result = $this->getList($searchCriteria)->getItems();
+
+        return current($result);
+    }
+
+    /**
+     * Delete by Order Related Data
+     *
+     * @param OrderRelatedDataInterface $orderRelatedData
+     * @return bool
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function delete(OrderRelatedDataInterface $orderRelatedData)
+    {
+        try {
+            $this->resource->delete($orderRelatedData);
+        } catch (\Exception $exception) {
+            throw new CouldNotDeleteException(__($exception->getMessage()));
+        }
+        return true;
+    }
+
+    /**
+     * Delete by Order Increment Id and Code
+     *
+     * @param string $orderIncrementId
+     * @param string $code
+     * @return bool true on success
+     * @throws \Magento\Framework\Exception\NoSuchEntityException
+     * @throws \Magento\Framework\Exception\LocalizedException
+     */
+    public function deleteByOrderIncrementIdAndCode($orderIncrementId, $code)
+    {
+        $orderRelatedData = $this->getByOrderIncrementIdAndCode($orderIncrementId, $code);
+
+        if($orderRelatedData instanceof OrderRelatedDataInterface){
+            return $this->delete($orderRelatedData);
+        }
+
+        throw new NoSuchEntityException(__('Object not found'));
+    }
+
+    /**
+     * @param Search\FilterGroup $filterGroup
+     * @param ResourceModel\OrderRelatedData\Collection $collection
+     */
+    protected function addFilterGroupToCollection(Search\FilterGroup $filterGroup, Collection $collection)
+    {
+        $fields = [];
+        $conditions = [];
+        foreach ($filterGroup->getFilters() as $filter) {
+            $condition = $filter->getConditionType();
+            $fields[] = $filter->getField();
+            $conditions[] = [$condition => $filter->getValue()];
+        }
+        if ($fields) {
+            $collection->addFieldToFilter($fields, $conditions);
+        }
+    }
+}

--- a/Model/ResourceModel/OrderRelatedData.php
+++ b/Model/ResourceModel/OrderRelatedData.php
@@ -1,0 +1,18 @@
+<?php
+namespace SnowIO\ExtendedSalesRepositories\Model\ResourceModel;
+
+use SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface;
+use Magento\Framework\Model\ResourceModel\Db;
+
+class OrderRelatedData extends Db\AbstractDb
+{
+    const TABLE = 'snowio_order_relateddata';
+
+    /**
+     * @inheritDoc
+     */
+    protected function _construct()
+    {
+        $this->_init(self::TABLE, OrderRelatedDataInterface::ID);
+    }
+}

--- a/Model/ResourceModel/OrderRelatedData/Collection.php
+++ b/Model/ResourceModel/OrderRelatedData/Collection.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace SnowIO\ExtendedSalesRepositories\Model\ResourceModel\OrderRelatedData;
+
+use SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface;
+use SnowIO\ExtendedSalesRepositories\Model;
+use Magento\Framework\Model\ResourceModel\Db;
+
+class Collection extends Db\Collection\AbstractCollection
+{
+    protected $_idFieldName = OrderRelatedDataInterface::ID;
+
+    /**
+     * @inheritdoc
+     */
+    protected function _construct()
+    {
+        $this->_init(Model\OrderRelatedData::class, Model\ResourceModel\OrderRelatedData::class);
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,0 +1,91 @@
+<?php
+namespace SnowIO\ExtendedSalesRepositories\Setup;
+
+use Magento\Framework\DB\Ddl\Table;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+use SnowIO\ExtendedSalesRepositories\Model\ResourceModel;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\DB\Adapter\AdapterInterface;
+
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function upgrade(SchemaSetupInterface $setup, ModuleContextInterface $context)
+    {
+        $setup->startSetup();
+
+        if (version_compare($context->getVersion(), '1.1.0', '<')) {
+            $this->installOrderRelatedDataSchema($setup);
+        }
+
+        $setup->endSetup();
+    }
+
+    /**
+     * @param SchemaSetupInterface $setup
+     */
+    protected function installOrderRelatedDataSchema(SchemaSetupInterface $setup)
+    {
+        $table = $setup->getConnection()->newTable(
+            $setup->getTable(ResourceModel\OrderRelatedData::TABLE)
+        )->addColumn(
+            'id',
+            Table::TYPE_SMALLINT,
+            null,
+            ['identity' => true, 'nullable' => false, 'primary' => true],
+            'ID'
+        )->addColumn(
+            'order_increment_id',
+            Table::TYPE_TEXT,
+            50,
+            ['nullable' => false],
+            'Order Increment Id'
+        )->addColumn(
+            'code',
+            Table::TYPE_TEXT,
+            255,
+            ['nullable' => false],
+            'Key for the Data'
+        )->addColumn(
+            'value',
+            Table::TYPE_TEXT,
+            255,
+            ['nullable' => true],
+            'Value for the Data'
+        )->addColumn(
+            'created_at',
+            \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
+            null,
+            [
+                'nullable' => false,
+                'default' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT
+            ],
+            'Created At'
+        )->addColumn(
+            'updated_at',
+            \Magento\Framework\DB\Ddl\Table::TYPE_TIMESTAMP,
+            null,
+            [
+                'nullable' => false,
+                'default' => \Magento\Framework\DB\Ddl\Table::TIMESTAMP_INIT
+            ],
+            'Created At'
+        )->addIndex(
+            $setup->getIdxName(
+                $setup->getTable(ResourceModel\OrderRelatedData::TABLE),
+                ['order_entity_id', 'code'],
+                AdapterInterface::INDEX_TYPE_UNIQUE
+            ),
+            ['order_increment_id', 'code'],
+            ['type' => AdapterInterface::INDEX_TYPE_UNIQUE]
+        )
+        ->setComment(
+            'Persist Key/Value information to reference to an Order'
+        );
+
+        $setup->getConnection()->createTable($table);
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -3,6 +3,7 @@ namespace SnowIO\ExtendedSalesRepositories\Setup;
 
 use Magento\Framework\DB\Ddl\Table;
 use Magento\Framework\Setup\UpgradeSchemaInterface;
+use SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface;
 use SnowIO\ExtendedSalesRepositories\Model\ResourceModel;
 use Magento\Framework\Setup\ModuleContextInterface;
 use Magento\Framework\Setup\SchemaSetupInterface;
@@ -76,11 +77,20 @@ class UpgradeSchema implements UpgradeSchemaInterface
         )->addIndex(
             $setup->getIdxName(
                 $setup->getTable(ResourceModel\OrderRelatedData::TABLE),
-                ['order_entity_id', 'code'],
+                [OrderRelatedDataInterface::ORDER_INCREMENT_ID, OrderRelatedDataInterface::CODE],
                 AdapterInterface::INDEX_TYPE_UNIQUE
             ),
-            ['order_increment_id', 'code'],
+            [OrderRelatedDataInterface::ORDER_INCREMENT_ID, OrderRelatedDataInterface::CODE],
             ['type' => AdapterInterface::INDEX_TYPE_UNIQUE]
+        )
+        ->addIndex(
+            $setup->getIdxName(
+                $setup->getTable(ResourceModel\OrderRelatedData::TABLE),
+                [OrderRelatedDataInterface::ORDER_INCREMENT_ID],
+                AdapterInterface::INDEX_TYPE_INDEX
+            ),
+            [OrderRelatedDataInterface::ORDER_INCREMENT_ID],
+            ['type' => AdapterInterface::INDEX_TYPE_INDEX]
         )
         ->setComment(
             'Persist Key/Value information to reference to an Order'

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,10 +1,6 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <preference
-            for="SnowIO\ExtendedSalesRepositories\Api\Data\AdditionalInformationFieldInterface"
-            type="SnowIO\ExtendedSalesRepositories\Model\AdditionalInformationField" />
-
-    <preference
             for="SnowIO\ExtendedSalesRepositories\Api\ShipOrderByIncrementIdInterface"
             type="SnowIO\ExtendedSalesRepositories\Model\ShipOrderByIncrementId" />
 
@@ -25,7 +21,6 @@
             type="Magento\Framework\Api\SearchResults" />
 
     <type name="Magento\Sales\Api\OrderRepositoryInterface">
-        <plugin name="processAdditionalInformation" type="SnowIO\ExtendedSalesRepositories\Plugin\OrderRepositoryPlugin" disabled="true" />
+        <plugin name="OrderRelatedDataExtensionAttributeOperations" type="SnowIO\ExtendedSalesRepositories\Plugin\OrderRepositoryPlugin" />
     </type>
-
 </config>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -12,6 +12,18 @@
             for="SnowIO\ExtendedSalesRepositories\Api\CreditmemoByOrderIncrementIdInterface"
             type="SnowIO\ExtendedSalesRepositories\Model\CreditmemoByOrderIncrementId" />
 
+    <preference
+            for="SnowIO\ExtendedSalesRepositories\Api\OrderRelatedDataRepositoryInterface"
+            type="SnowIO\ExtendedSalesRepositories\Model\OrderRelatedDataRepository" />
+
+    <preference
+            for="SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface"
+            type="SnowIO\ExtendedSalesRepositories\Model\OrderRelatedData" />
+
+    <preference
+            for="SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataSearchResultsInterface"
+            type="Magento\Framework\Api\SearchResults" />
+
     <type name="Magento\Sales\Api\OrderRepositoryInterface">
         <plugin name="processAdditionalInformation" type="SnowIO\ExtendedSalesRepositories\Plugin\OrderRepositoryPlugin" disabled="true" />
     </type>

--- a/etc/extension_attributes.xml
+++ b/etc/extension_attributes.xml
@@ -3,9 +3,7 @@
         <attribute code="order_increment_id" type="string" />
     </extension_attributes>
 
-    <extension_attributes for="Magento\Sales\Api\Data\OrderPaymentInterface">
-        <attribute code="additional_information_json" type="string" />
+    <extension_attributes for="Magento\Sales\Api\Data\OrderInterface">
+        <attribute code="snowio_relateddata" type="SnowIO\ExtendedSalesRepositories\Api\Data\OrderRelatedDataInterface[]" />
     </extension_attributes>
-
-
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,5 @@
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SnowIO_ExtendedSalesRepositories" setup_version="1.0.0">
+    <module name="SnowIO_ExtendedSalesRepositories" setup_version="1.1.0">
         <sequence>
             <module name="Magento_Sales" />
         </sequence>

--- a/etc/webapi.xml
+++ b/etc/webapi.xml
@@ -12,4 +12,28 @@
             <resource ref="Magento_Sales::creditmemo" />
         </resources>
     </route>
+    <route url="/V1/order/:orderIncrementId/relateddata" method="GET">
+        <service class="SnowIO\ExtendedSalesRepositories\Api\OrderRelatedDataRepositoryInterface" method="getList"/>
+        <resources>
+            <resource ref="Magento_Sales::sales" />
+        </resources>
+    </route>
+    <route url="/V1/order/:orderIncrementId/relateddata/:code" method="GET">
+        <service class="SnowIO\ExtendedSalesRepositories\Api\OrderRelatedDataRepositoryInterface" method="getByOrderIncrementIdAndCode"/>
+        <resources>
+            <resource ref="Magento_Sales::sales" />
+        </resources>
+    </route>
+    <route url="/V1/order/:orderIncrementId/relateddata/:code" method="PUT">
+        <service class="SnowIO\ExtendedSalesRepositories\Api\OrderRelatedDataRepositoryInterface" method="save"/>
+        <resources>
+            <resource ref="Magento_Sales::sales" />
+        </resources>
+    </route>
+    <route url="/V1/order/:orderIncrementId/relateddata/:code" method="DELETE">
+        <service class="SnowIO\ExtendedSalesRepositories\Api\OrderRelatedDataRepositoryInterface" method="delete"/>
+        <resources>
+            <resource ref="Magento_Sales::sales" />
+        </resources>
+    </route>
 </routes>


### PR DESCRIPTION
Add new Entity that will hold key/value information against order.

![Screenshot 2019-08-01 at 23 18 30](https://user-images.githubusercontent.com/33385/62331141-ea530b00-b4b2-11e9-9c7f-23b0fd628d5c.png)

### Usage

#### To Persist
PUT https://localhost/rest/V1/order/000000001/relateddata/someAttributeKey
Payload:
```json
{
	"orderRelatedData": {
		"order_increment_id": "000000001",
		"code": "someAttributeKey",
		"value": "some attribute value"
	}
}
```
#### To Delete
DELETE https://localhost/rest/V1/order/000000001/relateddata/someAttributeKey

#### To Get
GET https://localhost/rest/V1/order/000000001/relateddata/someAttributeKey

#### Database
```
mysql> select * from snowio_order_relateddata;
+----+--------------------+------------------+----------------------+---------------------+
| id | order_increment_id | code             | value                | created_at          |
+----+--------------------+------------------+----------------------+---------------------+
|  1 | 000000001          | someAttributeKey | some attribute value | 2019-08-01 21:45:02 |
+----+--------------------+------------------+----------------------+---------------------+
1 row in set (0.00 sec)
```

#### Expose These values on get orders and list orders endpoint
```json
{
  …
  "extension_attributes": {
    "snowio_relateddata": [
      {"someAttributeKey": "some attribute value”}
    ]
  …
}
```