### PR TITLE
Fix `smallint` used as auto increment on `snowio_order_relateddata` table

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,7 +1,8 @@
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="SnowIO_ExtendedSalesRepositories" setup_version="1.1.0">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+    <module name="SnowIO_ExtendedSalesRepositories" setup_version="1.1.1">
         <sequence>
-            <module name="Magento_Sales" />
+            <module name="Magento_Sales"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
### Description
The `id` field for the `snowio_order_relateddata` has been set to a `smallint`. This means that its maximum auto increment size is `32767` which is easily depleted. This PR updates the column to `int(10) unsigned` which has a maximum size of `4294967295`